### PR TITLE
Removing Death Blast from the Goombamancer skillset

### DIFF
--- a/wrongtown_goombanistan/abilities/100025_Death_Blast.json
+++ b/wrongtown_goombanistan/abilities/100025_Death_Blast.json
@@ -20,9 +20,8 @@
 	},
 	"id": 100025,
 	"image": 112,
-	"level": 1,
+	"level": 99,
 	"name": "Death Blast",
-	"profession": 100099,
 	"range": 10,
 	"target": "aoe_tile"
 }


### PR DESCRIPTION
Was left in there as an artefact of late testing phase where I temporarily added the skill to the Goombamancer tree.